### PR TITLE
add write permissions for statuses to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       checks: write
+      statuses: write
       pull-requests: read
       contents: read
     steps:


### PR DESCRIPTION
Not sure if if it's github or something changed here, but now this seems to be required.

Thanks for the action btw - way easier than using merge-gatekeeper!!